### PR TITLE
GitHub Actionsでパッケージングできるように対応

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,32 @@
+name: Packaging for EC-CUBE Plugin
+on:
+  release:
+    types: [ published ]
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased')
+      uses: actions/checkout@master
+    - name: Packaging
+      if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased')
+      working-directory: ../
+      run: |
+        rm -rf $GITHUB_WORKSPACE/.github
+        find $GITHUB_WORKSPACE -name "dummy" -print0 | xargs -0 rm -rf
+        find $GITHUB_WORKSPACE -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf
+        find $GITHUB_WORKSPACE -name ".git*" -type d -print0 | xargs -0 rm -rf
+        chmod -R o+w $GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE
+        tar cvzf ../${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz ./*
+    - name: Upload binaries to release of TGZ
+      if: github.event_name == 'release' && (github.event.action == 'published' || github.event.action == 'prereleased')
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ runner.workspace }}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz
+        asset_name: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz
+        tag: ${{ github.ref }}
+        overwrite: true


### PR DESCRIPTION
実行結果
https://github.com/EC-CUBE/ProductImagesUploader/actions

assetsにプラグインのパッケージが追加されることを確認
https://github.com/EC-CUBE/ProductImagesUploader/releases/tag/1.0.0